### PR TITLE
Add user management with roles

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, request, redirect, url_for, session, jsonify
+from flask import Flask, render_template, request, redirect, url_for, session, jsonify, abort
 from models import db, User, Email, Vehicle, Branch, Booking, CalendarEvent, Competitor
 from database import seed_data
 
@@ -49,6 +49,7 @@ def login():
         user = User.query.filter_by(username=username, password=password).first()
         if user:
             session["user"] = username
+            session["role"] = user.role
             return redirect(url_for("dashboard"))
         error = "Invalid credentials. Please try again."
     return render_template("login.html", error=error)
@@ -58,7 +59,8 @@ def login():
 def dashboard():
     if "user" not in session:
         return redirect(url_for("login"))
-    return render_template("dashboard.html", stats=DASHBOARD_STATS, nav_items=NAV_ITEMS)
+    return render_template("dashboard.html", stats=DASHBOARD_STATS, nav_items=NAV_ITEMS,
+                           current_user=session["user"], current_role=session.get("role", "user"))
 
 
 @app.route("/logout")
@@ -198,6 +200,59 @@ def get_events():
 @app.route("/api/competitors", methods=["GET"])
 def get_competitors():
     return jsonify([c.to_dict() for c in Competitor.query.all()])
+
+
+# --- API: Session ---
+
+@app.route("/api/session", methods=["GET"])
+def get_session():
+    if "user" not in session:
+        return jsonify({"error": "Not logged in"}), 401
+    return jsonify({"username": session["user"], "role": session.get("role", "user")})
+
+
+# --- API: Users ---
+
+@app.route("/api/users", methods=["GET"])
+def get_users():
+    return jsonify([u.to_dict() for u in User.query.all()])
+
+
+@app.route("/api/users", methods=["POST"])
+def create_user():
+    if session.get("role") != "admin":
+        abort(403)
+    data = request.json
+    if User.query.filter_by(username=data["username"]).first():
+        return jsonify({"error": "Username already exists"}), 400
+    user = User(username=data["username"], password=data["password"],
+                role=data.get("role", "user"))
+    db.session.add(user)
+    db.session.commit()
+    return jsonify(user.to_dict()), 201
+
+
+@app.route("/api/users/<int:id>", methods=["PUT"])
+def update_user(id):
+    if session.get("role") != "admin":
+        abort(403)
+    user = db.get_or_404(User, id)
+    data = request.json
+    for field in ["username", "password", "role"]:
+        if field in data:
+            setattr(user, field, data[field])
+    db.session.commit()
+    return jsonify(user.to_dict())
+
+
+@app.route("/api/users/<int:id>", methods=["DELETE"])
+def delete_user(id):
+    if session.get("role") != "admin":
+        abort(403)
+    user = db.get_or_404(User, id)
+    db.session.delete(user)
+    db.session.commit()
+    return "", 204
 
 
 if __name__ == "__main__":

--- a/database.py
+++ b/database.py
@@ -1,11 +1,24 @@
+from sqlalchemy import text
 from models import db, User, Email, Vehicle, Branch, Booking, CalendarEvent, Competitor
 
 
+def migrate():
+    """Add role column to user table if it doesn't exist."""
+    with db.engine.connect() as conn:
+        columns = [row[1] for row in conn.execute(text("PRAGMA table_info(user)"))]
+        if "role" not in columns:
+            conn.execute(text("ALTER TABLE user ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT 'user'"))
+            conn.commit()
+
+
 def seed_data():
+    migrate()
+
     if User.query.first():
         return  # Already seeded
 
-    db.session.add(User(username="admin", password="admin"))
+    db.session.add(User(username="admin", password="admin", role="admin"))
+    db.session.add(User(username="operator", password="operator", role="user"))
 
     for e in [
         Email(from_email="john.doe@email.com", subject="Booking Request #1234", date="2026-03-05", status="New"),

--- a/database.py
+++ b/database.py
@@ -3,22 +3,31 @@ from models import db, User, Email, Vehicle, Branch, Booking, CalendarEvent, Com
 
 
 def migrate():
-    """Add role column to user table if it doesn't exist."""
+    """Add role column to user table if it doesn't exist, then fix admin role."""
     with db.engine.connect() as conn:
         columns = [row[1] for row in conn.execute(text("PRAGMA table_info(user)"))]
         if "role" not in columns:
             conn.execute(text("ALTER TABLE user ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT 'user'"))
-            conn.commit()
+        # Ensure the admin user always has role='admin'
+        conn.execute(text("UPDATE user SET role = 'admin' WHERE username = 'admin'"))
+        conn.commit()
 
 
 def seed_data():
     migrate()
 
-    if User.query.first():
-        return  # Already seeded
+    if not User.query.first():
+        db.session.add(User(username="admin", password="admin", role="admin"))
+        db.session.add(User(username="operator", password="operator", role="user"))
 
-    db.session.add(User(username="admin", password="admin", role="admin"))
-    db.session.add(User(username="operator", password="operator", role="user"))
+    # Add operator user if it was missing from an earlier seed
+    if not User.query.filter_by(username="operator").first():
+        db.session.add(User(username="operator", password="operator", role="user"))
+
+    db.session.commit()
+
+    if Email.query.first():
+        return  # Other data already seeded
 
     for e in [
         Email(from_email="john.doe@email.com", subject="Booking Request #1234", date="2026-03-05", status="New"),

--- a/models.py
+++ b/models.py
@@ -7,6 +7,10 @@ class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)
     password = db.Column(db.String(120), nullable=False)
+    role = db.Column(db.String(20), nullable=False, default="user")
+
+    def to_dict(self):
+        return {"id": self.id, "username": self.username, "role": self.role}
 
 
 class Email(db.Model):

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21,6 +21,10 @@ tags:
     description: Calendar events
   - name: competitors
     description: Competitor analysis
+  - name: users
+    description: User management (admin only for write operations)
+  - name: session
+    description: Current session information
 
 paths:
 
@@ -262,6 +266,92 @@ paths:
                 items:
                   $ref: '#/components/schemas/Competitor'
 
+  /api/session:
+    get:
+      tags: [session]
+      summary: Get current session user info
+      responses:
+        '200':
+          description: Current user info
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionInfo'
+        '401':
+          description: Not logged in
+
+  /api/users:
+    get:
+      tags: [users]
+      summary: List all users
+      responses:
+        '200':
+          description: List of users
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+    post:
+      tags: [users]
+      summary: Create a new user (admin only)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserInput'
+      responses:
+        '201':
+          description: User created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '400':
+          description: Username already exists
+        '403':
+          description: Admin role required
+
+  /api/users/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+    put:
+      tags: [users]
+      summary: Update a user (admin only)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserInput'
+      responses:
+        '200':
+          description: Updated user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '403':
+          description: Admin role required
+        '404':
+          description: User not found
+    delete:
+      tags: [users]
+      summary: Delete a user (admin only)
+      responses:
+        '204':
+          description: User deleted
+        '403':
+          description: Admin role required
+        '404':
+          description: User not found
+
 components:
   schemas:
 
@@ -423,3 +513,36 @@ components:
           type: integer
         trend:
           type: string
+
+    SessionInfo:
+      type: object
+      properties:
+        username:
+          type: string
+        role:
+          type: string
+          enum: [admin, user]
+
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+        username:
+          type: string
+        role:
+          type: string
+          enum: [admin, user]
+
+    UserInput:
+      type: object
+      required: [username, password]
+      properties:
+        username:
+          type: string
+        password:
+          type: string
+        role:
+          type: string
+          enum: [admin, user]
+          default: user

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,32 +2,40 @@
 
 ## Task 1: Hello World Python Script ✅
 ## Task 2: Flask Dashboard Application ✅
+## Task 3: Dashboard Section Pages ✅
+## Task 4: SQLite Database + OpenAPI Spec ✅
 
-## Task 3: Dashboard Section Pages
+## Task 5: User Management with Roles ✅
 
 ### Plan
 - [x] git pull main
-- [x] Create GitHub issue #5
-- [x] Create branch `feature/issue-5-dashboard-sections`
-- [x] Update `tasks/todo.md`
-- [ ] Update `base.html` — add Chart.js + Leaflet.js CDN
-- [ ] Update `dashboard.html` — all 8 sections with JS navigation
-- [ ] Commit, push, open PR
+- [x] Create GitHub issue #9
+- [x] Create branch `feature/issue-9-user-management`
+- [x] Update `models.py` — add `role` field to User model
+- [x] Update `database.py` — seed admin (role=admin) + add operator user (role=user) + migration
+- [x] Update `app.py` — user CRUD API endpoints + `/api/session` + role in session
+- [x] Update `dashboard.html` — Users section + sidebar username/role display
+- [x] Update `openapi.yaml` — add user management + session endpoints
+- [x] Commit, push, open PR
 
-### Sections
-| Section         | UI Pattern |
-|----------------|-----------|
-| Dashboard       | Existing stats cards (keep) |
-| Email Processor | Table, status badges, add/delete/mark-read |
-| Fleet Management| Clickable cards grid, detail modal |
-| Branches        | Leaflet map + editable list (add/edit/delete) |
-| Bookings        | Table with add/edit/delete modal form |
-| Calendar        | Monthly grid calendar with events |
-| Analytics       | Chart.js: line, bar, doughnut charts |
-| Konkurencija    | Competitor comparison cards |
+### Role Design
+| Role  | Permissions |
+|-------|------------|
+| admin | Full access: view/add/edit/delete all users |
+| user  | Restricted: view users list only, cannot add/edit/delete |
 
-### Notes
-- Single dashboard.html, JS show/hide sections
-- All data hardcoded in JS arrays
-- Refresh button top-right on every section
-- Chart.js + Leaflet.js via CDN
+### Changes per file
+| File | Change |
+|------|--------|
+| `models.py` | Added `role` field (admin/user) to User model + `to_dict()` |
+| `database.py` | Added `migrate()` for existing DBs + seeded operator user (role=user) |
+| `app.py` | Store role in session on login, pass to template, added `/api/session` + user CRUD (admin-guarded) |
+| `dashboard.html` | New Users nav item + Users section + sidebar shows username + role badge |
+| `openapi.yaml` | Added user management endpoints + session endpoint + User/UserInput/SessionInfo schemas |
+
+### Review
+- **models.py**: Added `role = db.Column(db.String(20), nullable=False, default='user')` and `to_dict()` to User model.
+- **database.py**: Added `migrate()` function that uses `PRAGMA table_info` to safely add the `role` column to existing databases. Seed now creates `admin` (role=admin) and `operator` (role=user).
+- **app.py**: Login now stores `session["role"]`. Dashboard route passes `current_user` and `current_role` to template. Added `/api/session` (GET), `/api/users` (GET/POST), `/api/users/<id>` (PUT/DELETE) — POST/PUT/DELETE check `session.get("role") != "admin"` and return 403.
+- **dashboard.html**: Sidebar bottom now shows avatar icon, username, and role badge (purple for admin, blue for user). Added Users nav item and Users section with table. JS uses `CURRENT_ROLE` variable (embedded from Flask) to show/hide Add/Edit/Delete buttons. Self-delete is disabled. User modal has username, password, and role fields.
+- **openapi.yaml**: Added `users` and `session` tags, `/api/session`, `/api/users`, `/api/users/{id}` paths, and `User`, `UserInput`, `SessionInfo` schemas.

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -13,7 +13,8 @@
                 <small class="text-muted">Agent System</small>
             </div>
         </div>
-        <ul class="nav nav-pills flex-column" style="flex: 1 1 0; overflow-y: auto; min-height: 0;">
+        <div style="flex: 1 1 0; overflow-y: auto; overflow-x: hidden; min-height: 0;">
+        <ul class="nav nav-pills flex-column">
             <li class="nav-item mb-1">
                 <a href="#" class="nav-link text-white active" onclick="showSection('dashboard', this); return false;">
                     <i class="bi bi-speedometer2 me-2"></i>Dashboard
@@ -60,6 +61,7 @@
                 </a>
             </li>
         </ul>
+        </div>
         <div class="border-top border-secondary pt-3 mt-3">
             <div class="d-flex align-items-center mb-2">
                 <div class="bg-secondary rounded-circle d-flex align-items-center justify-content-center me-2" style="width:32px;height:32px;">

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -54,8 +54,22 @@
                     <i class="bi bi-graph-up me-2"></i>Konkurencija
                 </a>
             </li>
+            <li class="nav-item mb-1">
+                <a href="#" class="nav-link text-white" onclick="showSection('users', this); return false;">
+                    <i class="bi bi-people me-2"></i>Users
+                </a>
+            </li>
         </ul>
         <div class="border-top border-secondary pt-3 mt-3">
+            <div class="d-flex align-items-center mb-2">
+                <div class="bg-secondary rounded-circle d-flex align-items-center justify-content-center me-2" style="width:32px;height:32px;">
+                    <i class="bi bi-person-fill text-white"></i>
+                </div>
+                <div>
+                    <div class="text-white small fw-semibold">{{ current_user }}</div>
+                    <span class="badge {% if current_role == 'admin' %}bg-purple{% else %}bg-primary{% endif %}" style="{% if current_role == 'admin' %}background-color:#6f42c1!important;{% endif %}font-size:0.65rem;">{{ current_role }}</span>
+                </div>
+            </div>
             <a href="/logout" class="nav-link text-muted">
                 <i class="bi bi-box-arrow-left me-2"></i>Logout
             </a>
@@ -291,6 +305,36 @@
             <div id="competitors-grid" class="row g-4"></div>
         </div>
 
+        <!-- Users Section -->
+        <div id="section-users" class="content-section p-4 d-none">
+            <div class="d-flex justify-content-between align-items-center mb-4">
+                <div>
+                    <h2 class="fw-bold mb-1">Users</h2>
+                    <p class="text-muted mb-0">Manage system users and roles</p>
+                </div>
+                <div class="d-flex gap-2">
+                    <button id="btn-add-user" class="btn btn-primary btn-sm" onclick="openUserModal()" style="display:none!important;">
+                        <i class="bi bi-plus me-1"></i>Add User
+                    </button>
+                    <button class="btn btn-outline-secondary btn-sm" onclick="refreshSection('users')">
+                        <i class="bi bi-arrow-clockwise me-1"></i>Refresh
+                    </button>
+                </div>
+            </div>
+            <div class="card border-0 shadow-sm">
+                <div class="card-body p-0">
+                    <div class="table-responsive">
+                        <table class="table table-hover mb-0">
+                            <thead class="table-light">
+                                <tr><th>Username</th><th>Role</th><th id="users-actions-th" style="display:none;">Actions</th></tr>
+                            </thead>
+                            <tbody id="users-table-body"></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+
     </div>
 </div>
 
@@ -431,12 +475,49 @@
     </div>
 </div>
 
+<!-- User Modal -->
+<div class="modal fade" id="userModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="user-modal-title">Add User</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <input type="hidden" id="user-id">
+                <div class="mb-3">
+                    <label class="form-label">Username</label>
+                    <input type="text" id="user-username" class="form-control">
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Password</label>
+                    <input type="password" id="user-password" class="form-control">
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Role</label>
+                    <select id="user-role" class="form-select">
+                        <option value="user">user</option>
+                        <option value="admin">admin</option>
+                    </select>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" onclick="saveUser()">Save</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <script>
 // ========== HELPERS ==========
 const api = (url, method='GET', body=null) => fetch(url, {
     method, headers: {'Content-Type': 'application/json'},
     body: body ? JSON.stringify(body) : null
 }).then(r => r.ok ? (r.status === 204 ? null : r.json()) : Promise.reject(r));
+
+const CURRENT_USER = "{{ current_user }}";
+const CURRENT_ROLE = "{{ current_role }}";
 
 // ========== NAVIGATION ==========
 function showSection(name, el) {
@@ -451,6 +532,7 @@ function showSection(name, el) {
     if (name === 'calendar') renderCalendar();
     if (name === 'analytics') initCharts();
     if (name === 'konkurencija') renderCompetitors();
+    if (name === 'users') renderUsers();
 }
 
 function refreshSection(name) {
@@ -461,6 +543,7 @@ function refreshSection(name) {
     if (name === 'calendar') renderCalendar();
     if (name === 'analytics') { chartsInitialized = false; initCharts(); }
     if (name === 'konkurencija') renderCompetitors();
+    if (name === 'users') renderUsers();
 }
 
 // ========== EMAIL ==========
@@ -815,6 +898,68 @@ function renderCompetitors() {
             </div>`;
         }).join('');
     });
+}
+
+// ========== USERS ==========
+let usersCache = [];
+
+function renderUsers() {
+    const isAdmin = CURRENT_ROLE === 'admin';
+    document.getElementById('btn-add-user').style.display = isAdmin ? '' : 'none';
+    document.getElementById('users-actions-th').style.display = isAdmin ? '' : 'none';
+    api('/api/users').then(users => {
+        usersCache = users;
+        document.getElementById('users-table-body').innerHTML = users.map(u => {
+            const roleBadge = u.role === 'admin'
+                ? `<span class="badge" style="background-color:#6f42c1;">admin</span>`
+                : `<span class="badge bg-primary">user</span>`;
+            const isSelf = u.username === CURRENT_USER;
+            const actions = isAdmin ? `
+                <td>
+                    <button class="btn btn-sm btn-outline-primary me-1" onclick="editUser(${u.id})"><i class="bi bi-pencil"></i></button>
+                    <button class="btn btn-sm btn-outline-danger" onclick="deleteUser(${u.id})" ${isSelf ? 'disabled title="Cannot delete own account"' : ''}><i class="bi bi-trash"></i></button>
+                </td>` : '';
+            return `<tr><td>${u.username}</td><td>${roleBadge}</td>${actions}</tr>`;
+        }).join('');
+    });
+}
+
+function openUserModal() {
+    document.getElementById('user-id').value = '';
+    document.getElementById('user-username').value = '';
+    document.getElementById('user-password').value = '';
+    document.getElementById('user-role').value = 'user';
+    document.getElementById('user-modal-title').textContent = 'Add User';
+    new bootstrap.Modal(document.getElementById('userModal')).show();
+}
+
+function editUser(id) {
+    const u = usersCache.find(u => u.id === id);
+    document.getElementById('user-id').value = u.id;
+    document.getElementById('user-username').value = u.username;
+    document.getElementById('user-password').value = '';
+    document.getElementById('user-role').value = u.role;
+    document.getElementById('user-modal-title').textContent = 'Edit User';
+    new bootstrap.Modal(document.getElementById('userModal')).show();
+}
+
+function saveUser() {
+    const id = document.getElementById('user-id').value;
+    const data = {
+        username: document.getElementById('user-username').value,
+        role: document.getElementById('user-role').value,
+    };
+    const pwd = document.getElementById('user-password').value;
+    if (pwd) data.password = pwd;
+    const req = id ? api(`/api/users/${id}`, 'PUT', data) : api('/api/users', 'POST', data);
+    req.then(() => {
+        bootstrap.Modal.getInstance(document.getElementById('userModal')).hide();
+        renderUsers();
+    });
+}
+
+function deleteUser(id) {
+    api(`/api/users/${id}`, 'DELETE').then(() => renderUsers());
 }
 </script>
 {% endblock %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -3,8 +3,8 @@
 <div class="d-flex" style="min-height: 100vh;">
 
     <!-- Sidebar -->
-    <div class="d-flex flex-column p-3 text-white" style="width: 240px; min-height: 100vh; background-color: #1a1f2e; position: sticky; top: 0; height: 100vh; overflow-y: auto;">
-        <div class="d-flex align-items-center mb-4 pb-3 border-bottom border-secondary">
+    <div class="d-flex flex-column p-3 text-white" style="width: 240px; background-color: #1a1f2e; position: sticky; top: 0; height: 100vh; overflow: hidden;">
+        <div class="d-flex align-items-center mb-4 pb-3 border-bottom border-secondary flex-shrink-0">
             <div class="bg-primary rounded-3 p-2 me-2">
                 <i class="bi bi-car-front-fill text-white"></i>
             </div>
@@ -13,7 +13,7 @@
                 <small class="text-muted">Agent System</small>
             </div>
         </div>
-        <ul class="nav nav-pills flex-column mb-auto">
+        <ul class="nav nav-pills flex-column" style="flex: 1 1 0; overflow-y: auto; min-height: 0;">
             <li class="nav-item mb-1">
                 <a href="#" class="nav-link text-white active" onclick="showSection('dashboard', this); return false;">
                     <i class="bi bi-speedometer2 me-2"></i>Dashboard
@@ -70,7 +70,7 @@
                     <span class="badge {% if current_role == 'admin' %}bg-purple{% else %}bg-primary{% endif %}" style="{% if current_role == 'admin' %}background-color:#6f42c1!important;{% endif %}font-size:0.65rem;">{{ current_role }}</span>
                 </div>
             </div>
-            <a href="/logout" class="nav-link text-muted">
+            <a href="/logout" class="nav-link text-white-50">
                 <i class="bi bi-box-arrow-left me-2"></i>Logout
             </a>
         </div>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -313,7 +313,7 @@
                     <p class="text-muted mb-0">Manage system users and roles</p>
                 </div>
                 <div class="d-flex gap-2">
-                    <button id="btn-add-user" class="btn btn-primary btn-sm" onclick="openUserModal()" style="display:none!important;">
+                    <button id="btn-add-user" class="btn btn-primary btn-sm" onclick="openUserModal()" style="display:none;">
                         <i class="bi bi-plus me-1"></i>Add User
                     </button>
                     <button class="btn btn-outline-secondary btn-sm" onclick="refreshSection('users')">


### PR DESCRIPTION
## Summary
- Add `role` field (admin/user) to User model with DB migration for existing databases
- Seed admin user (role=admin) and new operator user (role=user)
- Add `/api/session` and full user CRUD endpoints with admin-only guard for write operations
- Add Users section to dashboard with role-based UI (add/edit/delete visible to admin only)
- Update sidebar bottom to show current username and role badge (purple=admin, blue=user)
- Update openapi.yaml with user management and session endpoints

## Test plan
- [ ] Login as `admin`/`admin` — sidebar shows "admin" badge (purple), Users section shows Add/Edit/Delete buttons
- [ ] Login as `operator`/`operator` — sidebar shows "user" badge (blue), Users section shows view-only table
- [ ] Admin: add new user, edit existing user, verify delete is disabled on own account
- [ ] Verify non-admin gets 403 on POST/PUT/DELETE `/api/users`
- [ ] Verify `/api/session` returns `{username, role}` for logged-in user

Fixes #9