### PR TITLE
Add light/dark theme switcher

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -188,3 +188,33 @@
 
 ### Review
 - **dashboard.html**: Sidebar bottom block removed entirely — sidebar is now nav-only. Main content column changed to `d-flex flex-column` with a `flex-shrink-0` topbar (fixed 56px height, white background, border-bottom). User avatar, username, role badge (purple for admin, blue for user) and Logout button sit on the right side of the topbar, always visible regardless of scroll or screen size.
+
+---
+
+## Task 7: Light/Dark Theme Switcher
+
+### Plan
+- [x] git pull main
+- [x] Create GitHub issue #13
+- [x] Create branch `feature/issue-13-theme-switcher`
+- [x] Update `templates/base.html` — add inline script to apply saved theme before render (prevents flash)
+- [x] Update `templates/dashboard.html` — add sun/moon toggle button to topbar
+- [x] Commit, push, open PR
+
+### Design
+- Use Bootstrap 5.3 native dark mode (`data-bs-theme` attribute on `<html>`)
+- Default: `light`
+- Toggle: sun icon (☀) in dark mode → click → switches to light; moon icon (☾) in light mode → click → switches to dark
+- Preference saved in `localStorage` key `theme`
+- Inline `<script>` in `<head>` of `base.html` reads `localStorage` and sets `data-bs-theme` before page paint — prevents white flash on dark mode reload
+- Topbar toggle button placed left of the user avatar in the topbar
+
+### Changes per file
+| File | Change |
+|------|--------|
+| `templates/base.html` | Added `data-bs-theme="light"` to `<html>` tag; inline script in `<head>` to read `localStorage` and apply theme before render; removed hardcoded `body { background-color }` |
+| `templates/dashboard.html` | Changed topbar `bg-white` → `bg-body` (theme-aware); added moon/sun toggle button; `toggleTheme()` JS function + page-load icon sync IIFE |
+
+### Review
+- **base.html**: Inline script runs before CSS loads — sets `data-bs-theme` from `localStorage` — prevents flash of wrong theme on page reload. Default `data-bs-theme="light"` on `<html>` is the fallback when no preference is saved. Hardcoded body background removed so Bootstrap dark mode can control it.
+- **dashboard.html**: Topbar button shows moon icon in light mode, sun icon in dark mode. `toggleTheme()` reads current theme, toggles it, saves to `localStorage`, updates icon. An IIFE on page load syncs the icon to match the current theme (handles the case where the page loads already in dark mode from `localStorage`).

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,15 +1,14 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-bs-theme="light">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>RentACar - Agent System</title>
+    <!-- Apply saved theme before render to prevent flash -->
+    <script>(function(){var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-bs-theme',t);})();</script>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
     <link href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" rel="stylesheet">
-    <style>
-        body { background-color: #f0f2f5; }
-    </style>
 </head>
 <body>
     {% block content %}{% endblock %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -68,8 +68,11 @@
     <div class="flex-grow-1 d-flex flex-column" style="overflow-y: auto;">
 
         <!-- Topbar -->
-        <div class="d-flex justify-content-end align-items-center px-4 bg-white border-bottom flex-shrink-0" style="height:56px;">
+        <div class="d-flex justify-content-end align-items-center px-4 bg-body border-bottom flex-shrink-0" style="height:56px;">
             <div class="d-flex align-items-center gap-3">
+                <button class="btn btn-outline-secondary btn-sm" onclick="toggleTheme()" title="Toggle theme">
+                    <i id="theme-icon" class="bi bi-moon-stars-fill"></i>
+                </button>
                 <div class="bg-secondary rounded-circle d-flex align-items-center justify-content-center" style="width:32px;height:32px;">
                     <i class="bi bi-person-fill text-white small"></i>
                 </div>
@@ -522,6 +525,21 @@ const api = (url, method='GET', body=null) => fetch(url, {
 
 const CURRENT_USER = "{{ current_user }}";
 const CURRENT_ROLE = "{{ current_role }}";
+
+// ========== THEME ==========
+function toggleTheme() {
+    const html = document.documentElement;
+    const isDark = html.getAttribute('data-bs-theme') === 'dark';
+    const next = isDark ? 'light' : 'dark';
+    html.setAttribute('data-bs-theme', next);
+    localStorage.setItem('theme', next);
+    document.getElementById('theme-icon').className = next === 'dark' ? 'bi bi-sun-fill' : 'bi bi-moon-stars-fill';
+}
+// Set correct icon on load
+(function() {
+    const t = localStorage.getItem('theme') || 'light';
+    document.getElementById('theme-icon').className = t === 'dark' ? 'bi bi-sun-fill' : 'bi bi-moon-stars-fill';
+})();
 
 // ========== NAVIGATION ==========
 function showSection(name, el) {


### PR DESCRIPTION
## Summary
- Added Bootstrap 5.3 native dark mode support (`data-bs-theme` on `<html>`)
- Inline script in `<head>` applies saved theme before page paint (prevents flash)
- Sun/moon toggle button in topbar switches and persists theme to `localStorage`

Fixes #13